### PR TITLE
Support for TEMPLATED_EMAIL_PLAIN_FILTER

### DIFF
--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -1,8 +1,11 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage, EmailMultiAlternatives, get_connection
 from django.template import Context, TemplateDoesNotExist
 from django.template.loader import get_template
+from django.utils.importlib import import_module
 from django.utils.translation import ugettext as _
+import six
 
 from templated_email.utils import _get_node, BlockNotFound
 

--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -5,7 +5,6 @@ from django.template import Context, TemplateDoesNotExist
 from django.template.loader import get_template
 from django.utils.importlib import import_module
 from django.utils.translation import ugettext as _
-import six
 
 from templated_email.utils import _get_node, BlockNotFound
 
@@ -106,7 +105,7 @@ class TemplateBackend(object):
         if 'html' in response and not 'plain' in response:
             toplain = getattr(settings, 'TEMPLATED_EMAIL_PLAIN_FILTER', None)
             if toplain:
-                if isinstance(toplain, six.string_types):
+                if isinstance(toplain, basestring):
                     mod_name, klass_name = toplain.rsplit('.', 1)
                     try:
                         mod = import_module(mod_name)


### PR DESCRIPTION
Added support for `TEMPLATED_EMAIL_PLAIN_FILTER`.

If template have not plain text part, this part can be automatically generated from HTML version via custom filter function defined in settings.

For example setting.

    TEMPLATED_EMAIL_PLAIN_FILTER = 'project.portal.email.plainfilter'

and custom filter

    def plainfilter(html):
        encoder = HTML2Text()

        return encoder.handle(html)

User will get email with html and plain text message markdown formatted. 

You free to use your filter function implementation and define it in settings.